### PR TITLE
Enable unsafe floating point opreations

### DIFF
--- a/scripts/cmake/CMakeToolchainDeluge.cmake
+++ b/scripts/cmake/CMakeToolchainDeluge.cmake
@@ -66,6 +66,7 @@ add_link_options(${ARCH_FLAGS})
 
 add_compile_options(
   -fmessage-length=0
+  -funsafe-math-optimizations # required to use NEON instead of VFPv3 for floating point
 )
 
 set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)


### PR DESCRIPTION
Despite having `-mfpu=neon`, GCC is not generating NEON instructions, and is instead generating the slower (non-pipelined) VFP instructions due to NEON not being fully IEE-754 compliant. See https://gcc.gnu.org/onlinedocs/gcc/ARM-Options.html#index-mfpu-1 for details. For optimization details see https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#index-funsafe-math-optimizations