### PR TITLE
Cleanup and modernize patcher

### DIFF
--- a/src/deluge/model/instrument/kit.cpp
+++ b/src/deluge/model/instrument/kit.cpp
@@ -825,7 +825,7 @@ void Kit::setupWithoutActiveClip(ModelStack* modelStack) {
 				FREEZE_WITH_ERROR("E174");
 			}
 
-			soundDrum->patcher.performInitialPatching(soundDrum, (ParamManagerForTimeline*)paramManager);
+			soundDrum->patcher.performInitialPatching(*soundDrum, *(ParamManagerForTimeline*)paramManager);
 		}
 	}
 
@@ -926,7 +926,7 @@ bool Kit::setActiveClip(ModelStackWithTimelineCounter* modelStack, PgmChangeSend
 
 						SoundDrum* soundDrum = (SoundDrum*)thisNoteRow->drum;
 
-						soundDrum->patcher.performInitialPatching(soundDrum, &thisNoteRow->paramManager);
+						soundDrum->patcher.performInitialPatching(*soundDrum, thisNoteRow->paramManager);
 					}
 				}
 			}

--- a/src/deluge/model/note/note_row.cpp
+++ b/src/deluge/model/note/note_row.cpp
@@ -3778,7 +3778,7 @@ void NoteRow::setDrum(Drum* newDrum, Kit* kit, ModelStackWithNoteRow* modelStack
 		}
 
 		if (clip->isActiveOnOutput()) {
-			soundDrum->patcher.performInitialPatching(soundDrum, &paramManager);
+			soundDrum->patcher.performInitialPatching(*soundDrum, paramManager);
 		}
 	}
 

--- a/src/deluge/model/voice/voice.cpp
+++ b/src/deluge/model/voice/voice.cpp
@@ -202,7 +202,7 @@ bool Voice::noteOn(ModelStackWithVoice* modelStack, int32_t newNoteCodeBeforeArp
 	for (int32_t s = 0; s < util::to_underlying(kFirstLocalSource); s++) {
 		sourceValues[s] = sound.globalSourceValues[s];
 	}
-	patcher.performInitialPatching(&sound, paramManager);
+	patcher.performInitialPatching(sound, *paramManager);
 
 	// Setup and render envelopes - again. Because they're local params (since mid-late 2017), we really need to render
 	// them *after* initial patching is performed.
@@ -528,7 +528,8 @@ makeInactive: // Frequency too high to render! (Higher than 22.05kHz)
 	if (sound.getSynthMode() == SynthMode::FM) {
 		for (int32_t m = 0; m < kNumModulators; m++) {
 
-			if (sound.getSmoothedPatchedParamValue(params::LOCAL_MODULATOR_0_VOLUME + m, paramManager) == -2147483648) {
+			if (sound.getSmoothedPatchedParamValue(params::LOCAL_MODULATOR_0_VOLUME + m, *paramManager)
+			    == -2147483648) {
 				continue; // Only if modulator active
 			}
 
@@ -804,7 +805,7 @@ uint32_t Voice::getLocalLFOPhaseIncrement(LFO_ID lfoId, deluge::modulation::para
 		for (int32_t s = 0; s < util::to_underlying(kFirstLocalSource); s++) {
 			sourceValues[s] = sound.globalSourceValues[s];
 		}
-		patcher.performPatching(sourcesChanged, &sound, paramManager);
+		patcher.performPatching(sourcesChanged, sound, *paramManager);
 	}
 
 	// Sort out pitch

--- a/src/deluge/model/voice/voice.cpp
+++ b/src/deluge/model/voice/voice.cpp
@@ -70,7 +70,7 @@ PLACE_INTERNAL_FRUNK int32_t spareRenderingBuffer[4][SSI_TX_BUFFER_NUM_SAMPLES]
 
 // Hopefully I could make this use the spareRenderingBuffer instead...
 
-const PatchableInfo patchableInfoForVoice = {
+const Patcher::Config kPatcherConfigForVoice = {
     .paramFinalValuesOffset = offsetof(Voice, paramFinalValues) - offsetof(Voice, patcher),
     .sourceValuesOffset = offsetof(Voice, sourceValues) - offsetof(Voice, patcher),
     .firstParam = 0,
@@ -88,7 +88,7 @@ int32_t Voice::combineExpressionValues(const Sound& sound, int32_t expressionDim
 	return lshiftAndSaturate<1>(combinedValue);
 }
 
-Voice::Voice() : patcher(&patchableInfoForVoice) {
+Voice::Voice() : patcher(kPatcherConfigForVoice) {
 }
 
 // Unusually, modelStack may be supplied as NULL, because when unassigning all voices e.g. on song swap, we won't have

--- a/src/deluge/model/voice/voice.cpp
+++ b/src/deluge/model/voice/voice.cpp
@@ -71,7 +71,6 @@ PLACE_INTERNAL_FRUNK int32_t spareRenderingBuffer[4][SSI_TX_BUFFER_NUM_SAMPLES]
 // Hopefully I could make this use the spareRenderingBuffer instead...
 
 const Patcher::Config kPatcherConfigForVoice = {
-    .paramFinalValuesOffset = offsetof(Voice, paramFinalValues) - offsetof(Voice, patcher),
     .firstParam = 0,
     .firstNonVolumeParam = params::FIRST_LOCAL_NON_VOLUME,
     .firstHybridParam = params::FIRST_LOCAL__HYBRID,
@@ -87,7 +86,7 @@ int32_t Voice::combineExpressionValues(const Sound& sound, int32_t expressionDim
 	return lshiftAndSaturate<1>(combinedValue);
 }
 
-Voice::Voice() : patcher(kPatcherConfigForVoice, sourceValues) {
+Voice::Voice() : patcher(kPatcherConfigForVoice, sourceValues, paramFinalValues) {
 }
 
 // Unusually, modelStack may be supplied as NULL, because when unassigning all voices e.g. on song swap, we won't have

--- a/src/deluge/model/voice/voice.cpp
+++ b/src/deluge/model/voice/voice.cpp
@@ -72,7 +72,6 @@ PLACE_INTERNAL_FRUNK int32_t spareRenderingBuffer[4][SSI_TX_BUFFER_NUM_SAMPLES]
 
 const Patcher::Config kPatcherConfigForVoice = {
     .paramFinalValuesOffset = offsetof(Voice, paramFinalValues) - offsetof(Voice, patcher),
-    .sourceValuesOffset = offsetof(Voice, sourceValues) - offsetof(Voice, patcher),
     .firstParam = 0,
     .firstNonVolumeParam = params::FIRST_LOCAL_NON_VOLUME,
     .firstHybridParam = params::FIRST_LOCAL__HYBRID,
@@ -88,7 +87,7 @@ int32_t Voice::combineExpressionValues(const Sound& sound, int32_t expressionDim
 	return lshiftAndSaturate<1>(combinedValue);
 }
 
-Voice::Voice() : patcher(kPatcherConfigForVoice) {
+Voice::Voice() : patcher(kPatcherConfigForVoice, sourceValues) {
 }
 
 // Unusually, modelStack may be supplied as NULL, because when unassigning all voices e.g. on song swap, we won't have

--- a/src/deluge/model/voice/voice.h
+++ b/src/deluge/model/voice/voice.h
@@ -48,11 +48,11 @@ public:
 	///
 	/// This is just for the *local* params, specific to this Voice only
 	///
-	int32_t paramFinalValues[deluge::modulation::params::LOCAL_LAST];
+	std::array<int32_t, deluge::modulation::params::LOCAL_LAST> paramFinalValues;
 
 	// At the start of this list are local copies of the "global" ones. It's cheaper to copy them here than to pick and
 	// choose where the Patcher looks for them
-	int32_t sourceValues[kNumPatchSources];
+	std::array<int32_t, kNumPatchSources> sourceValues;
 
 	std::bitset<kNumExpressionDimensions> expressionSourcesCurrentlySmoothing;
 	std::bitset<kNumExpressionDimensions> expressionSourcesFinalValueChanged;

--- a/src/deluge/modulation/patch/patch_cable.cpp
+++ b/src/deluge/modulation/patch/patch_cable.cpp
@@ -17,6 +17,7 @@
 
 #include "modulation/patch/patch_cable.h"
 #include "definitions_cxx.hpp"
+#include "util/fixedpoint.h"
 
 void PatchCable::setup(PatchSource newFrom, uint8_t newTo, int32_t newAmount) {
 	from = newFrom;

--- a/src/deluge/modulation/patch/patch_cable.h
+++ b/src/deluge/modulation/patch/patch_cable.h
@@ -19,6 +19,7 @@
 
 #include "modulation/automation/auto_param.h"
 #include "modulation/params/param_descriptor.h"
+#include "util/fixedpoint.h"
 #include <cstdint>
 
 class Sound;
@@ -33,8 +34,13 @@ public:
 	void initAmount(int32_t value);
 	void makeUnusable();
 
+	[[gnu::always_inline]] [[nodiscard]] int32_t applyRangeAdjustment(int32_t value) const {
+		int32_t small = multiply_32x32_rshift32(value, *this->rangeAdjustmentPointer);
+		return signed_saturate<32 - 5>(small) << 3; // Not sure if these limits are as wide as they could be...
+	}
+
 	PatchSource from;
 	ParamDescriptor destinationParamDescriptor;
 	AutoParam param; // Amounts have to be within +1073741824 and -1073741824
-	int32_t const* rangeAdjustmentPointer;
+	int32_t const* rangeAdjustmentPointer = nullptr;
 };

--- a/src/deluge/modulation/patch/patcher.cpp
+++ b/src/deluge/modulation/patch/patcher.cpp
@@ -135,7 +135,6 @@ void Patcher::performPatching(uint32_t sourcesChanged, Sound* sound, ParamManage
 	}
 }
 
-// Declaring these next 4 as inline made no performance difference.
 int32_t Patcher::cableToLinearParamWithoutRangeAdjustment(int32_t source_value, int32_t cable_strength,
                                                           int32_t running_total) {
 	int32_t scaled_source = multiply_32x32_rshift32(source_value, cable_strength);
@@ -168,7 +167,8 @@ int32_t Patcher::cableToExpParam(const PatchCable& patch_cable, int32_t source_v
 	return running_total + patch_cable.applyRangeAdjustment(scaled_source);
 }
 
-int32_t Patcher::combineCablesLinearForRangeParam(Destination const* destination, ParamManager* paramManager) {
+[[gnu::always_inline]] int32_t Patcher::combineCablesLinearForRangeParam(Destination const* destination,
+                                                                         ParamManager* paramManager) {
 	int32_t running_total = 536870912; // 536870912 means "1". runningTotalCombination will not be allowed
 	                                   // to get bigger than 2147483647, which means "4".
 
@@ -198,11 +198,9 @@ int32_t Patcher::combineCablesLinearForRangeParam(Destination const* destination
 
 // Linear param - combine all cables by multiplying their values (values centred around 1). Inputs effectively range
 // from "0" to "2". Output (product) clips off at "4". Call this if (p < getFirstHybridParam()) - "Pan" sits at the end
-// of the linear params and is the exception to the rule - it doesn't want this multiplying treatment Having this inline
-// makes huge ~40% performance difference to performInitialPatching, I think because in that case it knows there are no
-// cables.
-inline int32_t Patcher::combineCablesLinear(Destination const* destination, uint32_t p, Sound* sound,
-                                            ParamManager* paramManager) {
+// of the linear params and is the exception to the rule - it doesn't want this multiplying treatment
+[[gnu::always_inline]] int32_t Patcher::combineCablesLinear(Destination const* destination, uint32_t p, Sound* sound,
+                                                            ParamManager* paramManager) {
 	int32_t running_total = 536870912; // 536870912 means "1". runningTotalCombination will not be allowed
 	                                   // to get bigger than 2147483647, which means "4".
 
@@ -233,8 +231,8 @@ inline int32_t Patcher::combineCablesLinear(Destination const* destination, uint
 // Call this if (p >= getFirstHybridParam())
 // Having this inline makes huge ~40% performance difference to performInitialPatching, I think because in that case it
 // knows there are no cables.
-inline int32_t Patcher::combineCablesExp(Destination const* destination, uint32_t param, Sound* sound,
-                                         ParamManager* paramManager) {
+[[gnu::always_inline]] int32_t Patcher::combineCablesExp(Destination const* destination, uint32_t param, Sound* sound,
+                                                         ParamManager* paramManager) {
 
 	int32_t running_total = 0;
 

--- a/src/deluge/modulation/patch/patcher.cpp
+++ b/src/deluge/modulation/patch/patcher.cpp
@@ -26,7 +26,7 @@
 namespace params = deluge::modulation::params;
 
 inline int32_t* Patcher::getParamFinalValuesPointer() {
-	return (int32_t*)((uint32_t)this + config.paramFinalValuesOffset);
+	return param_final_values_.data();
 }
 
 inline int32_t Patcher::getSourceValue(PatchSource s) {

--- a/src/deluge/modulation/patch/patcher.h
+++ b/src/deluge/modulation/patch/patcher.h
@@ -53,18 +53,18 @@ public:
 	void recalculateFinalValueForParamWithNoCables(int32_t p, Sound* sound, ParamManagerForTimeline* paramManager);
 
 private:
-	void applyRangeAdjustment(int32_t* patchedValue, PatchCable* patchCable);
 	int32_t combineCablesLinearForRangeParam(Destination const* destination, ParamManager* paramManager);
-	int32_t combineCablesLinear(Destination const* destination, uint32_t p, Sound* sound, ParamManager* paramManager);
-	int32_t combineCablesExp(Destination const* destination, uint32_t p, Sound* sound, ParamManager* paramManager);
-	void cableToLinearParamWithoutRangeAdjustment(int32_t sourceValue, int32_t cableStrength,
-	                                              int32_t* runningTotalCombination);
-	void cableToLinearParam(int32_t sourceValue, int32_t cableStrength, int32_t* runningTotalCombination,
-	                        PatchCable* patchCable);
-	void cableToExpParamWithoutRangeAdjustment(int32_t sourceValue, int32_t cableStrength,
-	                                           int32_t* runningTotalCombination);
-	void cableToExpParam(int32_t sourceValue, int32_t cableStrength, int32_t* runningTotalCombination,
-	                     PatchCable* patchCable);
+	int32_t combineCablesLinear(Destination const* destination, uint32_t param, Sound* sound,
+	                            ParamManager* paramManager);
+	int32_t combineCablesExp(Destination const* destination, uint32_t param, Sound* sound, ParamManager* paramManager);
+	static int32_t cableToLinearParamWithoutRangeAdjustment(int32_t source_value, int32_t cable_strength,
+	                                                        int32_t running_total);
+	int32_t cableToLinearParam(const PatchCable& cable, int32_t source_value, int32_t cable_strength,
+	                           int32_t running_total);
+	static int32_t cableToExpParamWithoutRangeAdjustment(int32_t source_value, int32_t cable_strength,
+	                                                     int32_t running_total);
+	int32_t cableToExpParam(const PatchCable& cable, int32_t source_value, int32_t cable_strength,
+	                        int32_t running_total);
 
 	const Config& config;
 	std::span<int32_t> source_values_;

--- a/src/deluge/modulation/patch/patcher.h
+++ b/src/deluge/modulation/patch/patcher.h
@@ -19,6 +19,7 @@
 
 #include "definitions_cxx.hpp"
 #include <cstdint>
+#include <span>
 
 struct CableGroup;
 
@@ -38,7 +39,6 @@ class Patcher {
 public:
 	struct Config {
 		int32_t paramFinalValuesOffset;
-		int32_t sourceValuesOffset;
 		uint8_t firstParam;
 		uint8_t firstNonVolumeParam;
 		uint8_t firstHybridParam;
@@ -47,7 +47,7 @@ public:
 		uint8_t globality;
 	};
 
-	Patcher(const Config& config) : config(config) {};
+	Patcher(const Config& config, std::span<int32_t> source_values) : config(config), source_values_(source_values) {};
 	void performInitialPatching(Sound* sound, ParamManager* paramManager);
 	void performPatching(uint32_t sourcesChanged, Sound* sound, ParamManagerForTimeline* paramManager);
 	void recalculateFinalValueForParamWithNoCables(int32_t p, Sound* sound, ParamManagerForTimeline* paramManager);
@@ -69,4 +69,5 @@ private:
 	int32_t getSourceValue(PatchSource s);
 
 	const Config& config;
+	std::span<int32_t> source_values_;
 };

--- a/src/deluge/modulation/patch/patcher.h
+++ b/src/deluge/modulation/patch/patcher.h
@@ -38,7 +38,6 @@ enum Globality {
 class Patcher {
 public:
 	struct Config {
-		int32_t paramFinalValuesOffset;
 		uint8_t firstParam;
 		uint8_t firstNonVolumeParam;
 		uint8_t firstHybridParam;
@@ -47,7 +46,8 @@ public:
 		uint8_t globality;
 	};
 
-	Patcher(const Config& config, std::span<int32_t> source_values) : config(config), source_values_(source_values) {};
+	Patcher(const Config& config, std::span<int32_t> source_values, std::span<int32_t> param_final_values)
+	    : config(config), source_values_(source_values), param_final_values_(param_final_values) {};
 	void performInitialPatching(Sound* sound, ParamManager* paramManager);
 	void performPatching(uint32_t sourcesChanged, Sound* sound, ParamManagerForTimeline* paramManager);
 	void recalculateFinalValueForParamWithNoCables(int32_t p, Sound* sound, ParamManagerForTimeline* paramManager);
@@ -70,4 +70,5 @@ private:
 
 	const Config& config;
 	std::span<int32_t> source_values_;
+	std::span<int32_t> param_final_values_;
 };

--- a/src/deluge/modulation/patch/patcher.h
+++ b/src/deluge/modulation/patch/patcher.h
@@ -65,8 +65,6 @@ private:
 	                                           int32_t* runningTotalCombination);
 	void cableToExpParam(int32_t sourceValue, int32_t cableStrength, int32_t* runningTotalCombination,
 	                     PatchCable* patchCable);
-	int32_t* getParamFinalValuesPointer();
-	int32_t getSourceValue(PatchSource s);
 
 	const Config& config;
 	std::span<int32_t> source_values_;

--- a/src/deluge/modulation/patch/patcher.h
+++ b/src/deluge/modulation/patch/patcher.h
@@ -48,23 +48,23 @@ public:
 
 	Patcher(const Config& config, std::span<int32_t> source_values, std::span<int32_t> param_final_values)
 	    : config(config), source_values_(source_values), param_final_values_(param_final_values) {};
-	void performInitialPatching(Sound* sound, ParamManager* paramManager);
-	void performPatching(uint32_t sourcesChanged, Sound* sound, ParamManagerForTimeline* paramManager);
-	void recalculateFinalValueForParamWithNoCables(int32_t p, Sound* sound, ParamManagerForTimeline* paramManager);
+	void performInitialPatching(Sound& sound, ParamManager& param_manager);
+	void performPatching(uint32_t sources_changed, Sound& sound, ParamManagerForTimeline& param_manager);
+	void recalculateFinalValueForParamWithNoCables(int32_t param, Sound& sound, ParamManagerForTimeline& param_manager);
 
 private:
-	int32_t combineCablesLinearForRangeParam(Destination const* destination, ParamManager* paramManager);
-	int32_t combineCablesLinear(Destination const* destination, uint32_t param, Sound* sound,
-	                            ParamManager* paramManager);
-	int32_t combineCablesExp(Destination const* destination, uint32_t param, Sound* sound, ParamManager* paramManager);
-	static int32_t cableToLinearParamWithoutRangeAdjustment(int32_t source_value, int32_t cable_strength,
-	                                                        int32_t running_total);
-	int32_t cableToLinearParam(const PatchCable& cable, int32_t source_value, int32_t cable_strength,
-	                           int32_t running_total);
-	static int32_t cableToExpParamWithoutRangeAdjustment(int32_t source_value, int32_t cable_strength,
-	                                                     int32_t running_total);
-	int32_t cableToExpParam(const PatchCable& cable, int32_t source_value, int32_t cable_strength,
-	                        int32_t running_total);
+	int32_t combineCablesLinearForRangeParam(Destination const* destination, ParamManager& param_manager);
+	int32_t combineCablesLinear(Destination const* destination, uint32_t param, Sound& sound,
+	                            ParamManager& param_manager);
+	int32_t combineCablesExp(Destination const* destination, uint32_t param, Sound& sound, ParamManager& param_manager);
+	static int32_t cableToLinearParamWithoutRangeAdjustment(int32_t running_total, int32_t source_value,
+	                                                        int32_t cable_strength);
+	int32_t cableToLinearParam(int32_t running_total, const PatchCable& cable, int32_t source_value,
+	                           int32_t cable_strength);
+	static int32_t cableToExpParamWithoutRangeAdjustment(int32_t running_total, int32_t source_value,
+	                                                     int32_t cable_strength);
+	int32_t cableToExpParam(int32_t running_total, const PatchCable& cable, int32_t source_value,
+	                        int32_t cable_strength);
 
 	const Config& config;
 	std::span<int32_t> source_values_;

--- a/src/deluge/modulation/patch/patcher.h
+++ b/src/deluge/modulation/patch/patcher.h
@@ -34,20 +34,20 @@ enum Globality {
 	GLOBALITY_GLOBAL = 1,
 };
 
-struct PatchableInfo {
-	int32_t paramFinalValuesOffset;
-	int32_t sourceValuesOffset;
-	uint8_t firstParam;
-	uint8_t firstNonVolumeParam;
-	uint8_t firstHybridParam;
-	uint8_t firstExpParam;
-	uint8_t endParams;
-	uint8_t globality;
-};
-
 class Patcher {
 public:
-	Patcher(const PatchableInfo* newInfo);
+	struct Config {
+		int32_t paramFinalValuesOffset;
+		int32_t sourceValuesOffset;
+		uint8_t firstParam;
+		uint8_t firstNonVolumeParam;
+		uint8_t firstHybridParam;
+		uint8_t firstExpParam;
+		uint8_t endParams;
+		uint8_t globality;
+	};
+
+	Patcher(const Config& config) : config(config) {};
 	void performInitialPatching(Sound* sound, ParamManager* paramManager);
 	void performPatching(uint32_t sourcesChanged, Sound* sound, ParamManagerForTimeline* paramManager);
 	void recalculateFinalValueForParamWithNoCables(int32_t p, Sound* sound, ParamManagerForTimeline* paramManager);
@@ -68,5 +68,5 @@ private:
 	int32_t* getParamFinalValuesPointer();
 	int32_t getSourceValue(PatchSource s);
 
-	const PatchableInfo* const patchableInfo;
+	const Config& config;
 };

--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -224,7 +224,7 @@ void init() {
 	        ->addParamCollectionSummary(paramManagerForSamplePreview->getPatchCableSetSummary());
 
 	((PatchCableSet*)modelStackWithParamCollection->paramCollection)->setupPatching(modelStackWithParamCollection);
-	sampleForPreview->patcher.performInitialPatching(sampleForPreview, paramManagerForSamplePreview);
+	sampleForPreview->patcher.performInitialPatching(*sampleForPreview, *paramManagerForSamplePreview);
 
 	sampleForPreview->sideChainSendLevel = 2147483647;
 

--- a/src/deluge/processing/sound/sound.cpp
+++ b/src/deluge/processing/sound/sound.cpp
@@ -70,7 +70,7 @@ extern "C" {
 // This is supported by GCC and other compilers should error (not warn), so turn off for this file
 #pragma GCC diagnostic ignored "-Winvalid-offsetof"
 
-const PatchableInfo patchableInfoForSound = {
+constexpr Patcher::Config kPatcherConfigForSound = {
     offsetof(Sound, paramFinalValues) - offsetof(Sound, patcher),
     offsetof(Sound, globalSourceValues) - offsetof(Sound, patcher),
     params::FIRST_GLOBAL,
@@ -81,7 +81,7 @@ const PatchableInfo patchableInfoForSound = {
     GLOBALITY_GLOBAL,
 };
 
-Sound::Sound() : patcher(&patchableInfoForSound) {
+Sound::Sound() : patcher(kPatcherConfigForSound) {
 	unpatchedParamKind_ = params::Kind::UNPATCHED_SOUND;
 
 	for (int32_t s = 0; s < kNumSources; s++) {

--- a/src/deluge/processing/sound/sound.cpp
+++ b/src/deluge/processing/sound/sound.cpp
@@ -423,7 +423,7 @@ void Sound::recalculatePatchingToParam(uint8_t p, ParamManagerForTimeline* param
 
 		// Whether global...
 		if (p >= params::FIRST_GLOBAL) {
-			patcher.recalculateFinalValueForParamWithNoCables(p, this, paramManager);
+			patcher.recalculateFinalValueForParamWithNoCables(p, *this, *paramManager);
 		}
 
 		// Or local (do to each voice)...
@@ -433,7 +433,7 @@ void Sound::recalculatePatchingToParam(uint8_t p, ParamManagerForTimeline* param
 				AudioEngine::activeVoices.getRangeForSound(this, ends);
 				for (int32_t v = ends[0]; v < ends[1]; v++) {
 					Voice* thisVoice = AudioEngine::activeVoices.getVoice(v);
-					thisVoice->patcher.recalculateFinalValueForParamWithNoCables(p, this, paramManager);
+					thisVoice->patcher.recalculateFinalValueForParamWithNoCables(p, *this, *paramManager);
 				}
 			}
 		}
@@ -2219,7 +2219,7 @@ bool Sound::allowsVeryLateNoteStart(InstrumentClip* clip, ParamManagerForTimelin
 
 bool Sound::isSourceActiveCurrently(int32_t s, ParamManagerForTimeline* paramManager) {
 	return (synthMode == SynthMode::RINGMOD
-	        || getSmoothedPatchedParamValue(params::LOCAL_OSC_A_VOLUME + s, paramManager) != -2147483648)
+	        || getSmoothedPatchedParamValue(params::LOCAL_OSC_A_VOLUME + s, *paramManager) != -2147483648)
 	       && (synthMode == SynthMode::FM || sources[s].oscType != OscType::SAMPLE
 	           || sources[s].hasAtLeastOneAudioFileLoaded());
 }
@@ -2248,7 +2248,7 @@ bool Sound::renderingOscillatorSyncCurrently(ParamManagerForTimeline* paramManag
 	if (synthMode == SynthMode::FM) {
 		return false;
 	}
-	return (getSmoothedPatchedParamValue(params::LOCAL_OSC_B_VOLUME, paramManager) != -2147483648
+	return (getSmoothedPatchedParamValue(params::LOCAL_OSC_B_VOLUME, *paramManager) != -2147483648
 	        || synthMode == SynthMode::RINGMOD);
 }
 
@@ -2533,7 +2533,7 @@ void Sound::render(ModelStackWithThreeMainThings* modelStack, std::span<StereoSa
 
 	// Perform the actual patching
 	if (sourcesChanged) {
-		patcher.performPatching(sourcesChanged, this, paramManager);
+		patcher.performPatching(sourcesChanged, *this, *paramManager);
 	}
 
 	// Setup some reverb-related stuff
@@ -2632,10 +2632,10 @@ void Sound::render(ModelStackWithThreeMainThings* modelStack, std::span<StereoSa
 
 		// Setup filters
 		bool thisHasFilters = hasFilters();
-		q31_t lpfMorph = getSmoothedPatchedParamValue(params::LOCAL_LPF_MORPH, paramManager);
-		q31_t lpfFreq = getSmoothedPatchedParamValue(params::LOCAL_LPF_FREQ, paramManager);
-		q31_t hpfMorph = getSmoothedPatchedParamValue(params::LOCAL_HPF_MORPH, paramManager);
-		q31_t hpfFreq = getSmoothedPatchedParamValue(params::LOCAL_HPF_FREQ, paramManager);
+		q31_t lpfMorph = getSmoothedPatchedParamValue(params::LOCAL_LPF_MORPH, *paramManager);
+		q31_t lpfFreq = getSmoothedPatchedParamValue(params::LOCAL_LPF_FREQ, *paramManager);
+		q31_t hpfMorph = getSmoothedPatchedParamValue(params::LOCAL_HPF_MORPH, *paramManager);
+		q31_t hpfFreq = getSmoothedPatchedParamValue(params::LOCAL_HPF_FREQ, *paramManager);
 		bool doLPF = thisHasFilters
 		             && (lpfMode == FilterMode::TRANSISTOR_24DB_DRIVE
 		                 || paramManager->getPatchCableSet()->doesParamHaveSomethingPatchedToIt(params::LOCAL_LPF_FREQ)

--- a/src/deluge/processing/sound/sound.cpp
+++ b/src/deluge/processing/sound/sound.cpp
@@ -71,14 +71,15 @@ extern "C" {
 #pragma GCC diagnostic ignored "-Winvalid-offsetof"
 
 const PatchableInfo patchableInfoForSound = {
-    (int32_t)(offsetof(Sound, paramFinalValues) - offsetof(Sound, patcher) - (params::FIRST_GLOBAL * sizeof(int32_t))),
+    offsetof(Sound, paramFinalValues) - offsetof(Sound, patcher),
     offsetof(Sound, globalSourceValues) - offsetof(Sound, patcher),
     params::FIRST_GLOBAL,
     params::FIRST_GLOBAL_NON_VOLUME,
     params::FIRST_GLOBAL_HYBRID,
     params::FIRST_GLOBAL_EXP,
     params::kNumParams,
-    GLOBALITY_GLOBAL};
+    GLOBALITY_GLOBAL,
+};
 
 Sound::Sound() : patcher(&patchableInfoForSound) {
 	unpatchedParamKind_ = params::Kind::UNPATCHED_SOUND;

--- a/src/deluge/processing/sound/sound.cpp
+++ b/src/deluge/processing/sound/sound.cpp
@@ -72,7 +72,6 @@ extern "C" {
 
 constexpr Patcher::Config kPatcherConfigForSound = {
     offsetof(Sound, paramFinalValues) - offsetof(Sound, patcher),
-    offsetof(Sound, globalSourceValues) - offsetof(Sound, patcher),
     params::FIRST_GLOBAL,
     params::FIRST_GLOBAL_NON_VOLUME,
     params::FIRST_GLOBAL_HYBRID,
@@ -81,7 +80,7 @@ constexpr Patcher::Config kPatcherConfigForSound = {
     GLOBALITY_GLOBAL,
 };
 
-Sound::Sound() : patcher(kPatcherConfigForSound) {
+Sound::Sound() : patcher(kPatcherConfigForSound, globalSourceValues) {
 	unpatchedParamKind_ = params::Kind::UNPATCHED_SOUND;
 
 	for (int32_t s = 0; s < kNumSources; s++) {

--- a/src/deluge/processing/sound/sound.cpp
+++ b/src/deluge/processing/sound/sound.cpp
@@ -71,16 +71,12 @@ extern "C" {
 #pragma GCC diagnostic ignored "-Winvalid-offsetof"
 
 constexpr Patcher::Config kPatcherConfigForSound = {
-    offsetof(Sound, paramFinalValues) - offsetof(Sound, patcher),
-    params::FIRST_GLOBAL,
-    params::FIRST_GLOBAL_NON_VOLUME,
-    params::FIRST_GLOBAL_HYBRID,
-    params::FIRST_GLOBAL_EXP,
-    params::kNumParams,
-    GLOBALITY_GLOBAL,
+    params::FIRST_GLOBAL,        params::FIRST_GLOBAL_NON_VOLUME,
+    params::FIRST_GLOBAL_HYBRID, params::FIRST_GLOBAL_EXP,
+    params::kNumParams,          GLOBALITY_GLOBAL,
 };
 
-Sound::Sound() : patcher(kPatcherConfigForSound, globalSourceValues) {
+Sound::Sound() : patcher(kPatcherConfigForSound, globalSourceValues, paramFinalValues) {
 	unpatchedParamKind_ = params::Kind::UNPATCHED_SOUND;
 
 	for (int32_t s = 0; s < kNumSources; s++) {

--- a/src/deluge/processing/sound/sound.h
+++ b/src/deluge/processing/sound/sound.h
@@ -269,14 +269,12 @@ public:
 	void detachSourcesFromAudioFiles();
 	void confirmNumVoices(char const* error);
 
-	inline int32_t getSmoothedPatchedParamValue(int32_t p,
-	                                            ParamManager* paramManager) { // Yup, inlining this helped a tiny bit.
+	// Yup, inlining this helped a tiny bit.
+	[[gnu::always_inline]] int32_t getSmoothedPatchedParamValue(int32_t p, ParamManager& paramManager) const {
 		if (paramLPF.p == p) {
 			return paramLPF.currentValue;
 		}
-		else {
-			return paramManager->getPatchedParamSet()->getValue(p);
-		}
+		return paramManager.getPatchedParamSet()->getValue(p);
 	}
 
 	void notifyValueChangeViaLPF(int32_t p, bool shouldDoParamLPF, ModelStackWithThreeMainThings const* modelStack,

--- a/src/deluge/processing/sound/sound.h
+++ b/src/deluge/processing/sound/sound.h
@@ -78,8 +78,9 @@ public:
 
 	// This is for the *global* params only, and begins with FIRST_GLOBAL_PARAM, so subtract that from your p value
 	// before accessing this array!
-	int32_t paramFinalValues[deluge::modulation::params::kNumParams - deluge::modulation::params::FIRST_GLOBAL];
-	int32_t globalSourceValues[util::to_underlying(kFirstLocalSource)];
+	std::array<int32_t, deluge::modulation::params::kNumParams - deluge::modulation::params::FIRST_GLOBAL>
+	    paramFinalValues;
+	std::array<int32_t, util::to_underlying(kFirstLocalSource)> globalSourceValues;
 
 	uint32_t sourcesChanged; // Applies from first source up to FIRST_UNCHANGEABLE_SOURCE
 

--- a/src/deluge/processing/sound/sound.h
+++ b/src/deluge/processing/sound/sound.h
@@ -88,23 +88,6 @@ public:
 	LFO globalLFO3;
 	LFOConfig lfoConfig[LFO_COUNT];
 
-	// December 3, 2024
-	// @todo
-	// Commit 6534979986d465a0acf01018e066e1d7ca1d170e
-	// From PR #2004 (LFO: cleanups in preparation for LFO2 sync support)
-	// (https://github.com/SynthstromAudible/DelugeFirmware/pull/2004)
-	// Removed four uint8_t lfo variables from this section and replaced them with the LFOConfig
-	// definition above. This unknowingly introduced a "release" bug which changed the sound of the
-	// Deluge synth engine compared to 1.1 as reported in issue #2660:
-	// (https://github.com/SynthstromAudible/DelugeFirmware/issues/2660)
-	// As a TEMPORARY solution, padding is being added here to fix the bug so as to not hold up
-	// the 1.2 Beta release.
-	// Emphasis on temporary as this bug needs a proper fix, otherwise it will keep coming back
-	// as changes get made to this Sound class.
-	// We think the issue relates to the use of "offsetof" in the param and patcher system
-	// (related to the paramFinalValues / globalSourceValues definitions above)
-	uint32_t temporaryPadding{0xDEADBEEF};
-
 	ModKnob modKnobs[kNumModButtons][kNumPhysicalModKnobs];
 
 	int32_t sideChainSendLevel;

--- a/src/deluge/processing/sound/sound_instrument.cpp
+++ b/src/deluge/processing/sound/sound_instrument.cpp
@@ -263,7 +263,7 @@ bool SoundInstrument::setActiveClip(ModelStackWithTimelineCounter* modelStack, P
 
 		if (modelStack) {
 			ParamManager* paramManager = &modelStack->getTimelineCounter()->paramManager;
-			patcher.performInitialPatching(this, paramManager);
+			patcher.performInitialPatching(*this, *paramManager);
 
 			// Grab mono expression params
 			ExpressionParamSet* expressionParams = paramManager->getExpressionParamSet();
@@ -294,7 +294,7 @@ void SoundInstrument::setupWithoutActiveClip(ModelStack* modelStack) {
 	if (!paramManager) {
 		FREEZE_WITH_ERROR("E173");
 	}
-	patcher.performInitialPatching(this, paramManager);
+	patcher.performInitialPatching(*this, *paramManager);
 
 	// Clear mono expression params
 	for (int32_t i = 0; i < kNumExpressionDimensions; i++) {


### PR DESCRIPTION
Cleans up patcher. Not a total overhaul, just enough to remove some of the craziness.

Future thoughts: I think a lot of the cable calculations can be vectorized by grouping them into categories based on type. If we _do_ move to vectorized versions, we also wouldn't need to stick to the strange fixed-point stuff going on in here.